### PR TITLE
First go at adding auto-clearing require cache

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,15 +1,59 @@
 #!/usr/bin/env node
 
 var repl = require('repl'),
-  util = require('util');
+  util = require('util').
+  q = require('q'),
+  uglifyJS = require('uglify-js'),
+  _ = require('underscore');
  
 var replServer = repl.start({});
+function nodeIsRequireCall(node) {
+  return ((node instanceof uglifyJS.AST_Call) && node.expression && 
+          node.expression.start && node.expression.start.value === 'require');
+}
 
+var foo = {};
 var defaultEval = replServer.eval;
 replServer.eval = function(cmd, context, filename, callback) {
-  defaultEval(cmd, context, filename, function(err, result) {
-    if (err || !result) return callback(err, result);
+  var requireFound = false;
+  if (cmd.match(/require/)) {  // Only bother parsing if we see "require"
+    cmd = cmd.substring(1, cmd.length - 1);
+    console.log(cmd);
+    var ast = uglifyJS.parse(cmd);
+    var requireFound;
+    var childrenBefore;
+    var walker = new uglifyJS.TreeWalker(function(node) {
+      if (nodeIsRequireCall(node)) {
+        requireFound = true;
+      }
+    });
+    ast.walk(walker);
 
+    if (requireFound) {
+      childrenBefore = _.pluck(context.module.children, 'id');
+    }
+    //console.log(require('util').inspect(ast));
+
+  }
+  foo.context = context;
+  foo.filename = filename;
+  defaultEval(cmd, context, filename, function(err, result) {
+    foo.module = module;
+    if (requireFound) {
+      //console.log(require('util').inspect(context.module.children));
+      var newModules = _.difference(_.pluck(context.module.children, 'id'), childrenBefore);
+      newModules.forEach(function(x) {
+        var modulePath = x;
+        require('fs').watchFile(modulePath, function(curr, prev) {
+          if (curr.mtime != prev.mtime) {
+            // module changed, dump it and its children from the require cache
+            console.log('Module change deteted, clearing cache!');
+            clearModule(modulePath);
+          }
+        });
+      });
+    }
+    if (err || !result) return callback(err, result);
 
     if (result.then && result.catch) {
       result.then(function(promiseResult) {
@@ -34,4 +78,65 @@ replServer.eval = function(cmd, context, filename, callback) {
 
   });
 };
+
+
+function clearModule(modulePath) {
+  function clearModuleInner(modulePath, moduleNode) {
+    if (moduleNode.id === modulePath) {
+      var modulePathsToClear = getModulePaths(moduleNode, []);
+      modulePathsToClear.forEach(function(modulePathToClear) {
+        require.cache[modulePathToClear] = undefined;
+      });
+    }
+    for (var i=0;i<moduleNode.children.length;i++) {
+      clearModuleInner(modulePath, moduleNode.children[i]);
+    }
+  }
+  return clearModuleInner(modulePath, foo.context.module);
+}
+
+
+function getModulePaths(moduleNode, memo) {
+  memo.push(moduleNode.filename);
+  for (var j=0;j<moduleNode.children.length;j++) {
+    memo = getModulePaths(moduleNode.children[j], memo);
+  }
+  return memo;
+}
+
+replServer.context.getCachedPaths = function(moduleNode) {
+
+  if (moduleNode) return getModulePaths(moduleNode, []);
+
+  var paths = [];
+  for(var i=0;i<foo.context.module.children.length;i++) {
+    paths = getModulePaths(foo.context.module.children[i], paths);
+  }
+
+  return paths;
+};
+
+
+
+
+
+replServer.context.getModule = function() {
+  return foo.context.module;
+};
+
+replServer.context.bar = function() {
+  var Q = require('q');
+  var deferred = Q.defer();
+  var util = require('util');
+  console.log(util.inspect(foo));
+  defaultEval("require('./getModule.js');", foo.context, foo.filename, function(err, result) {
+    if (err) return deferred.reject(err);
+    return deferred.resolve(result);
+  });
+  return deferred.promise;
+};
+replServer.context.getChildren = function() {
+  console.log(util.inspect(module.children));
+};
+replServer.context.test = foo;
 

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "promise-repl",
   "version": "0.1.8",
   "description": "A customized repl that makes hacking promise based async functions simple",
+  "dependencies": {
+    "3i-db": "git+ssh://git@github.com:thirdiron/node-3i-db.git#v0.7.0"
+  },
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
One thing that's annoyed me about working in the node REPL is that once you've required some module, in order to update it and load the updated code, you have to track down the full path to the module's file and delete its key in `require.cache` or else subsequent `require` calls within the REPL just return the cached, previously loaded, module.

This code is messy, but it successfully watches for `require` commands from the REPL, and adds file watchers to `require`d files.  Then if a file that's been `require`d is modified, it removes the keys for the required module and all of its children from `require.cache` so they can be reloaded.

Thinking a little more about this, I realize this probably should add file watchers to child dependencies of any required modules (which is not difficult to gather up using uglifyJS) and upon modification should clear the modified module as well as any parent modules in the dependency tree.
